### PR TITLE
feat(SpringDocAPI): adiciona o SpringDoc para facilitação da documentação de APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.13</version>
+   		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Estava conversando com o Isaque, que me solicitou uma documentação das APIs...

Adicionei o SpringDocs ao projeto com o objetivo de facilitar a documentação automática das APIs. Parece uma boa forma de fazer isso de maneira padronizada e simples de manter.

O SpringDocs gera automaticamente uma interface interativa (via Swagger UI) - na http://localhost:8080/swagger-ui.html - com base nas anotações já existentes nas classes e endpoints, o que pode ajudar bastante na comunicação entre times e na validação das rotas disponíveis.

Ainda é necessário documentar algumas exceções específicas, pois o SpringDocs não cobre esses casos automaticamente.

Gostaria da opinião de vocês sobre se vale a pena manter o SpringDocs no projeto...
Caso não achem interessante seguir com ele, podem negar o pull request sem problema.